### PR TITLE
[#31] version and build information

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
     # You may remove this if you don't use go modules.
     - go mod tidy
     # you may remove this if you don't need go generate
-    - go generate ./...
+    # - go generate ./...
 builds:
   - env:
       - CGO_ENABLED=0
@@ -14,6 +14,10 @@ builds:
       - windows
       - darwin
     main: ./cmd/gotouch
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.BuildCommit={{.ShortCommit}} -X main.BuildDate={{.Date}}
+    flags:
+      - -trimpath
     ignore:
       - goos:  windows
         goarch: arm64

--- a/cmd/gotouch/main.go
+++ b/cmd/gotouch/main.go
@@ -4,6 +4,12 @@ import (
 	"github.com/denizgursoy/gotouch/internal/commands"
 )
 
+var (
+	Version     = "v0.0.0"
+	BuildCommit = "0000000"
+	BuildDate   = "0000-00-00T00:00:00Z"
+)
+
 func main() {
-	commands.Execute()
+	commands.Execute(commands.BuildInfo{Version: Version, BuildCommit: BuildCommit, BuildDate: BuildDate})
 }

--- a/internal/commands/createCommand_test.go
+++ b/internal/commands/createCommand_test.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/denizgursoy/gotouch/internal/cloner"
 	"testing"
+
+	"github.com/denizgursoy/gotouch/internal/cloner"
 
 	"github.com/denizgursoy/gotouch/internal/compressor"
 	"github.com/denizgursoy/gotouch/internal/executor"
@@ -53,7 +54,7 @@ func TestGetCreateCommandHandler(t *testing.T) {
 
 			mockCommander.EXPECT().CreateNewProject(gomock.Eq(expectedCall))
 
-			command := CreateRootCommand(mockCommander)
+			command := CreateRootCommand(mockCommander, BuildInfo{})
 			command.SetArgs(getCreateTestArguments(argument.flag))
 
 			err := command.Execute()

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -7,27 +7,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Execute() {
-	rootCommand := CreateRootCommand(operator.GetInstance())
+type BuildInfo struct {
+	Version     string
+	BuildCommit string
+	BuildDate   string
+}
+
+func Execute(info BuildInfo) {
+	rootCommand := CreateRootCommand(operator.GetInstance(), info)
 	err := rootCommand.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
 }
 
-func CreateRootCommand(cmdr operator.Operator) *cobra.Command {
+func CreateRootCommand(cmdr operator.Operator, info BuildInfo) *cobra.Command {
 	createCommand := &cobra.Command{
-		Use:   "gotouch",
-		Short: "Helps you create new  projects",
-		Long: `Parses properties yaml provided with file flag. If no flag is provided, Gotouch will use the yaml at
-https://raw.githubusercontent.com/denizgursoy/go-touch-projects/main/package.yaml. 
+		Use:     "gotouch",
+		Version: info.Version,
+		Short:   "Helps you create new projects",
+		Long: `Gotouch helps you create new projects from templates.
+Version: ` + info.Version + ` Commit: ` + info.BuildCommit + ` Date: ` + info.BuildDate + `
+
+Parses properties yaml provided with file flag. If no flag is provided, Gotouch will use the yaml at
+https://raw.githubusercontent.com/denizgursoy/go-touch-projects/main/package.yaml.
+
 Gotouch will list the project structures in the yaml to user in order to make selection.
 Gotouch will ask for project name. Project name will be used to create directory to which archive file will be extracted.
 If selected project structure's language is go, project name will be used as module name. See below:
 
-Project Name						Module Name 						Directory Name
-my-app								my-app								my-app
-github.com/my-account/my-app		github.com/my-account/my-app		my-app
+Project Name                 | Module Name                  | Directory Name
+my-app                       | my-app                       | my-app
+github.com/my-account/my-app | github.com/my-account/my-app | my-app
 
 If no go.mod file exists in the template, Gotouch will create one with the module name.
 Gotouch will ask the questions in the selected project structure in order.`,

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -33,7 +33,7 @@ func TestCreateRootCommand(t *testing.T) {
 			},
 		}
 
-		actualCommand := CreateRootCommand(instance)
+		actualCommand := CreateRootCommand(instance, BuildInfo{})
 		checkCommandHasCorrectValues(t, expectedCommand, actualCommand)
 	})
 


### PR DESCRIPTION
Version and build information added in long information.

```sh
> gotouch -h
Gotouch helps you create new projects from templates.
Version: 1.4.4-next Commit: b8a4a54 Date: 2022-11-15T21:48:16Z

...
```

```sh
> gotouch -v
gotouch version 1.4.4-next
```